### PR TITLE
Refactor run_tex to solve issue #3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ addons:
   apt:
     packages:
     - texlive-latex-base
+    - latexmk
 install:
 - pip install -r requirements.txt
 script:

--- a/django_tex/core.py
+++ b/django_tex/core.py
@@ -16,10 +16,8 @@ def run_tex(source):
         with open(filename, 'x', encoding='utf-8') as f:
             f.write(source)
         latex_interpreter = getattr(settings, 'LATEX_INTERPRETER', DEFAULT_INTERPRETER)
-        latex_command = [f'cd {tempdir}', '&&', latex_interpreter]
-        latex_command += [f'-output-directory={tempdir}', '-interaction=batchmode', 'texput.tex']
         latex_command = f'{latex_interpreter} -output-directory={tempdir} -interaction=batchmode {filename}'
-        process = run(latex_command, stdout=PIPE, stderr=PIPE)
+        process = run(latex_command, stdout=PIPE, stderr=PIPE, shell=True)
         if process.returncode == 1:
             with open(os.path.join(tempdir, 'texput.log'), encoding='utf8') as f:
                 log = f.read()

--- a/django_tex/core.py
+++ b/django_tex/core.py
@@ -22,11 +22,14 @@ def run_tex(source):
             with open(os.path.join(tempdir, 'texput.log'), encoding='utf8') as f:
                 log = f.read()
             raise TexError(log=log, source=source)
-        if process.stderr:
-            raise Exception(process.stderr.decode('utf-8'))
         filepath = os.path.join(tempdir, 'texput.pdf')
-        with open(filepath, 'rb') as pdf_file:
-            pdf = pdf_file.read()
+        try:
+            with open(filepath, 'rb') as pdf_file:
+                pdf = pdf_file.read()
+        except FileNotFoundError:
+            if process.stderr:
+                raise Exception(process.stderr.decode('utf-8'))
+            raise
     return pdf
 
 def compile_template_to_pdf(template_name, context):

--- a/django_tex/core.py
+++ b/django_tex/core.py
@@ -18,11 +18,14 @@ def run_tex(source):
         latex_interpreter = getattr(settings, 'LATEX_INTERPRETER', DEFAULT_INTERPRETER)
         latex_command = [f'cd {tempdir}', '&&', latex_interpreter]
         latex_command += [f'-output-directory={tempdir}', '-interaction=batchmode', 'texput.tex']
-        process = run(' '.join(latex_command), shell=True, stdout=PIPE, stderr=PIPE)
+        latex_command = f'{latex_interpreter} -output-directory={tempdir} -interaction=batchmode {filename}'
+        process = run(latex_command, stdout=PIPE, stderr=PIPE)
         if process.returncode == 1:
             with open(os.path.join(tempdir, 'texput.log'), encoding='utf8') as f:
                 log = f.read()
             raise TexError(log=log, source=source)
+        if process.stderr:
+            raise Exception(process.stderr.decode('utf-8'))
         filepath = os.path.join(tempdir, 'texput.pdf')
         with open(filepath, 'rb') as pdf_file:
             pdf = pdf_file.read()

--- a/django_tex/core.py
+++ b/django_tex/core.py
@@ -16,7 +16,7 @@ def run_tex(source):
         with open(filename, 'x', encoding='utf-8') as f:
             f.write(source)
         latex_interpreter = getattr(settings, 'LATEX_INTERPRETER', DEFAULT_INTERPRETER)
-        latex_command = f'cd {tempdir} && {latex_interpreter} -interaction=batchmode {os.path.basename(filename)}'
+        latex_command = f'cd "{tempdir}" && {latex_interpreter} -interaction=batchmode {os.path.basename(filename)}'
         process = run(latex_command, shell=True, stdout=PIPE, stderr=PIPE)
         try:
             if process.returncode == 1:

--- a/django_tex/core.py
+++ b/django_tex/core.py
@@ -16,15 +16,14 @@ def run_tex(source):
         with open(filename, 'x', encoding='utf-8') as f:
             f.write(source)
         latex_interpreter = getattr(settings, 'LATEX_INTERPRETER', DEFAULT_INTERPRETER)
-        latex_command = f'{latex_interpreter} -output-directory={tempdir} -interaction=batchmode {filename}'
-        process = run(latex_command, stdout=PIPE, stderr=PIPE, shell=False)
-        if process.returncode == 1:
-            with open(os.path.join(tempdir, 'texput.log'), encoding='utf8') as f:
-                log = f.read()
-            raise TexError(log=log, source=source)
-        filepath = os.path.join(tempdir, 'texput.pdf')
+        latex_command = f'cd {tempdir} && {latex_interpreter} -interaction=batchmode {os.path.basename(filename)}'
+        process = run(latex_command, shell=True, stdout=PIPE, stderr=PIPE)
         try:
-            with open(filepath, 'rb') as pdf_file:
+            if process.returncode == 1:
+                with open(os.path.join(tempdir, 'texput.log'), encoding='utf8') as f:
+                    log = f.read()
+                raise TexError(log=log, source=source)
+            with open(os.path.join(tempdir, 'texput.pdf'), 'rb') as pdf_file:
                 pdf = pdf_file.read()
         except FileNotFoundError:
             if process.stderr:

--- a/django_tex/core.py
+++ b/django_tex/core.py
@@ -17,7 +17,7 @@ def run_tex(source):
             f.write(source)
         latex_interpreter = getattr(settings, 'LATEX_INTERPRETER', DEFAULT_INTERPRETER)
         latex_command = f'{latex_interpreter} -output-directory={tempdir} -interaction=batchmode {filename}'
-        process = run(latex_command, stdout=PIPE, stderr=PIPE, shell=True)
+        process = run(latex_command, stdout=PIPE, stderr=PIPE, shell=False)
         if process.returncode == 1:
             with open(os.path.join(tempdir, 'texput.log'), encoding='utf8') as f:
                 log = f.read()

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -42,6 +42,17 @@ class RunningTex(TestCase):
         pdf = run_tex(source)
         self.assertIsNotNone(pdf)
 
+    @override_settings(LATEX_INTERPRETER='latexmk -pdf')
+    def test_latexmk_test(self):
+        source = "\
+        \\documentclass{article}\n\
+        \\begin{document}\n\
+        This is a test!\n\
+        \\end{document}"
+
+        pdf = run_tex(source)
+        self.assertIsNotNone(pdf)
+
     @override_settings(LATEX_INTERPRETER='does_not_exist')
     def test_wrong_latex_interpreter(self):
         source = "\
@@ -70,7 +81,12 @@ class Exceptions(TestCase):
         self.assertEquals(source, cm.exception.source)
         self.assertRegex(cm.exception.log, r'^This is LuaTeX')
         self.assertRegex(cm.exception.message, r'^! Emergency stop')
-        self.assertRegex(cm.exception.message, r'End of file on the terminal\!$')
+        self.assertRegex(cm.exception.message, 
+            r'(End of file on the terminal\!$)|(job aborted, no legal \\end found)') # First alternative applies
+                                                                                     # if tex source is given to 
+                                                                                     # pdflatex via stdin.
+                                                                                     # Second, if tex source is
+                                                                                     # given as filename 
 
     @override_settings(LATEX_INTERPRETER='pdflatex')
     def test_pdflatex_exceptions(self):
@@ -84,7 +100,12 @@ class Exceptions(TestCase):
 
         self.assertRegex(cm.exception.log, r'^This is pdfTeX')
         self.assertRegex(cm.exception.message, r'^! Emergency stop')
-        self.assertRegex(cm.exception.message, r'End of file on the terminal\!$')
+        self.assertRegex(cm.exception.message, 
+            r'(End of file on the terminal\!$)|(job aborted, no legal \\end found)') # First alternative applies
+                                                                                     # if tex source is given to 
+                                                                                     # pdflatex via stdin.
+                                                                                     # Second, if tex source is
+                                                                                     # given as filename 
 
     def test_exception_unknown_command(self):
         source = "\

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -286,3 +286,23 @@ class Views(TestCase):
         self.assertIsInstance(response, HttpResponse)
         self.assertEquals(response['Content-Type'], 'application/pdf')
         self.assertEquals(response['Content-Disposition'], 'filename="test.pdf"')
+
+class LatexmkTest(TestCase):
+
+    def test_latexmk(self):
+        import os, subprocess, tempfile
+        with tempfile.TemporaryDirectory() as tempdir:
+            source = (
+                r'\documentclass{article}'
+                r'\begin{document}'
+                r'Test'
+                r'\end{document}'
+            )
+            filename = os.path.join(tempdir, 'test.tex')
+            with open(filename, 'x') as f:
+                f.write(source)
+            command = f'latexmk -pdf -output-directory={tempdir} {filename}'
+            process = subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            self.assertEqual(process.returncode, 2)
+            self.assertIn(f"Filename '{filename}' contains character not allowed for TeX file", process.stderr.decode('utf-8'))
+            self.assertIn('Stopping because of bad filename(s)', process.stderr.decode('utf-8'))

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -286,23 +286,3 @@ class Views(TestCase):
         self.assertIsInstance(response, HttpResponse)
         self.assertEquals(response['Content-Type'], 'application/pdf')
         self.assertEquals(response['Content-Disposition'], 'filename="test.pdf"')
-
-class LatexmkTest(TestCase):
-
-    def test_latexmk(self):
-        import os, subprocess, tempfile
-        with tempfile.TemporaryDirectory() as tempdir:
-            source = (
-                r'\documentclass{article}'
-                r'\begin{document}'
-                r'Test'
-                r'\end{document}'
-            )
-            filename = os.path.join(tempdir, 'test.tex')
-            with open(filename, 'x') as f:
-                f.write(source)
-            command = f'latexmk -pdf -output-directory={tempdir} {filename}'
-            process = subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            self.assertEqual(process.returncode, 2)
-            self.assertIn(f"Filename '{filename}' contains character not allowed for TeX file", process.stderr.decode('utf-8'))
-            self.assertIn('Stopping because of bad filename(s)', process.stderr.decode('utf-8'))


### PR DESCRIPTION
run_tex now gets its input from a temporary tex file. This allows
for the use of latexmk. latexmk can be invoked by setting
LATEX_INTERPRETER='latexmk -pdf'