### PR TITLE
Added another process run to create table of content

### DIFF
--- a/django_tex/core.py
+++ b/django_tex/core.py
@@ -18,6 +18,7 @@ def run_tex(source):
         latex_interpreter = getattr(settings, 'LATEX_INTERPRETER', DEFAULT_INTERPRETER)
         latex_command = f'cd "{tempdir}" && {latex_interpreter} -interaction=batchmode {os.path.basename(filename)}'
         process = run(latex_command, shell=True, stdout=PIPE, stderr=PIPE)
+        process = run(latex_command, shell=True, stdout=PIPE, stderr=PIPE)
         try:
             if process.returncode == 1:
                 with open(os.path.join(tempdir, 'texput.log'), encoding='utf8') as f:


### PR DESCRIPTION
In order to create table of content, list of figures and list of tables, LaTex has to compile the document twice. On the first it creates the files necessary (toc, ..) and uses them in the second run. 