### PR TITLE
Issue16

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ build/
 .idea/
 env/
 venv
+.vscode

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,15 @@
 language: python
 python:
   - '3.6'
-  - '3.7'
+  - '3.8'
 addons:
   apt:
     packages:
       - texlive-latex-base
       - latexmk
 env:
-  - DJANGO_VERSION=1.11.4
-  - DJANGO_VERSION=2.2.5
+  - DJANGO_VERSION=1.11
+  - DJANGO_VERSION=3.0
 install:
   - pip install Django~=$DJANGO_VERSION
   - pip install -r requirements.txt
@@ -23,4 +23,4 @@ deploy:
   on:
     tags: true
     branch: master
-    condition: "($DJANGO_VERSION = 2.2.5) AND (python = 3.6)"
+    condition: "($DJANGO_VERSION = 3.0) AND (python = 3.8)"

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,0 +1,2 @@
+black
+flake8

--- a/django_tex/core.py
+++ b/django_tex/core.py
@@ -10,12 +10,12 @@ from django.conf import settings
 DEFAULT_INTERPRETER = "lualatex"
 
 
-def run_tex(source):
+def run_tex(source, template_name=None):
     with tempfile.TemporaryDirectory() as tempdir:
-        return run_tex_in_directory(source, directory=tempdir)
+        return run_tex_in_directory(source, tempdir, template_name=template_name)
 
 
-def run_tex_in_directory(source, directory):
+def run_tex_in_directory(source, directory, template_name=None):
     filename = "texput.tex"
     command = getattr(settings, "LATEX_INTERPRETER", DEFAULT_INTERPRETER)
     latex_interpreter_options = getattr(settings, "LATEX_INTERPRETER_OPTIONS", "")
@@ -33,7 +33,7 @@ def run_tex_in_directory(source, directory):
         except FileNotFoundError:
             raise called_process_error
         else:
-            raise TexError(log=log, source=source)
+            raise TexError(log=log, source=source, template_name=template_name)
     with open(os.path.join(directory, "texput.pdf"), "rb") as f:
         pdf = f.read()
     return pdf
@@ -41,7 +41,7 @@ def run_tex_in_directory(source, directory):
 
 def compile_template_to_pdf(template_name, context):
     source = render_template_with_context(template_name, context)
-    return run_tex(source)
+    return run_tex(source, template_name=template_name)
 
 
 def render_template_with_context(template_name, context):

--- a/django_tex/core.py
+++ b/django_tex/core.py
@@ -33,7 +33,7 @@ def run_tex_in_directory(source, directory):
         except FileNotFoundError:
             raise called_process_error
         else:
-            raise TexError(log)
+            raise TexError(log=log, source=source)
     with open(os.path.join(directory, "texput.pdf"), "rb") as f:
         pdf = f.read()
     return pdf

--- a/django_tex/exceptions.py
+++ b/django_tex/exceptions.py
@@ -14,7 +14,7 @@ ERROR = re.compile(r"|".join(error_patterns), re.DOTALL + re.MULTILINE)
 class TexError(Exception):
     def __init__(self, log, source):
         self.log = log
-        self.source = source
+        self.source = source.splitlines()
 
         mo = ERROR.search(self.log)
 
@@ -22,18 +22,19 @@ class TexError(Exception):
 
         if mo.group("lineno"):
             lineno = int(mo.group("lineno")) - 1
-            source_lines = source.splitlines()
-            total = len(source_lines)
+            total = len(self.source)
             top = max(0, lineno - 5)
             bottom = min(lineno + 5, total)
+            source_lines = list(enumerate(self.source[top:bottom], top + 1))
+            line, during = source_lines[lineno - top]
 
             self.template_debug = {
                 "name": "template",
-                "message": mo.group(),
-                "source_lines": list(enumerate(source_lines[top:bottom], top + 1)),
-                "line": lineno + 1,
+                "message": self.message,
+                "source_lines": source_lines,
+                "line": line,
                 "before": "",
-                "during": source_lines[lineno],
+                "during": during,
                 "after": "",
                 "total": total,
                 "top": top,

--- a/django_tex/exceptions.py
+++ b/django_tex/exceptions.py
@@ -1,42 +1,28 @@
 import re
 
 
-def prettify_message(message):
-    """
-    Helper methods that removes consecutive whitespaces and newline characters
-    """
-    # Replace consecutive whitespaces with a single whitespace
-    message = re.sub(r"[ ]{2,}", " ", message)
-    # Replace consecutive newline characters, optionally separated by whitespace, with a single newline
-    message = re.sub(r"([\r\n][ \t]*)+", "\n", message)
-    return message
+error_pattern = r"|".join([
+    r"^\!.*?l\.(?P<lineno>\d+).*?$",
+    r"^\! Emergency stop.*?\*{3}.*?$",
+    r"^\!.*?$",
+])
 
 
-def tokenizer(code):
-    token_specification = [
-        ("ERROR", r"\! (.+[\r\n])+[\r\n]*"),
-        ("WARNING", r"latex warning.*"),
-        ("NOFILE", r"no file.*"),
-    ]
-    token_regex = "|".join(
-        "(?P<{}>{})".format(label, regex) for label, regex in token_specification
-    )
-    for m in re.finditer(token_regex, code, re.IGNORECASE):
-        token_dict = dict(type=m.lastgroup, message=prettify_message(m.group()))
-        yield token_dict
+ERROR = re.compile(error_pattern, re.DOTALL + re.MULTILINE)
 
 
 class TexError(Exception):
     def __init__(self, log):
         self.log = log
-        self.tokens = list(tokenizer(self.log))
         self.message = self.get_message()
 
     def get_message(self):
-        for token in self.tokens:
-            if token["type"] == "ERROR":
-                return token["message"]
-        return "No error message found in log"
+        mo = ERROR.search(self.log)
+        if mo:
+            message = mo.group()
+        else:
+            message = "No error message found."
+        return message
 
     def __str__(self):
         return self.message

--- a/django_tex/exceptions.py
+++ b/django_tex/exceptions.py
@@ -12,7 +12,7 @@ ERROR = re.compile(r"|".join(error_patterns), re.DOTALL + re.MULTILINE)
 
 
 class TexError(Exception):
-    def __init__(self, log, source):
+    def __init__(self, log, source, template_name=None):
         self.log = log
         self.source = source.splitlines()
 
@@ -29,7 +29,7 @@ class TexError(Exception):
             line, during = source_lines[lineno - top]
 
             self.template_debug = {
-                "name": "template",
+                "name": template_name,
                 "message": self.message,
                 "source_lines": source_lines,
                 "line": line,

--- a/django_tex/exceptions.py
+++ b/django_tex/exceptions.py
@@ -1,28 +1,53 @@
 import re
 
 
-error_pattern = r"|".join([
+error_patterns = [
     r"^\!.*?l\.(?P<lineno>\d+).*?$",
     r"^\! Emergency stop.*?\*{3}.*?$",
     r"^\!.*?$",
-])
+]
 
 
-ERROR = re.compile(error_pattern, re.DOTALL + re.MULTILINE)
+ERROR = re.compile(r"|".join(error_patterns), re.DOTALL + re.MULTILINE)
 
 
 class TexError(Exception):
-    def __init__(self, log):
+    def __init__(self, log, source):
         self.log = log
-        self.message = self.get_message()
+        self.source = source
 
-    def get_message(self):
         mo = ERROR.search(self.log)
-        if mo:
-            message = mo.group()
-        else:
-            message = "No error message found."
-        return message
+
+        self.message = mo.group() or "No error message found."
+
+        if mo.group("lineno"):
+            lineno = int(mo.group("lineno")) - 1
+            source_lines = source.splitlines()
+            total = len(source_lines)
+            top = max(0, lineno - 5)
+            bottom = min(lineno + 5, total)
+
+            self.template_debug = {
+                "name": "template",
+                "message": mo.group(),
+                "source_lines": list(enumerate(source_lines[top:bottom], top + 1)),
+                "line": lineno + 1,
+                "before": "",
+                "during": source_lines[lineno],
+                "after": "",
+                "total": total,
+                "top": top,
+                "bottom": bottom,
+            }
+
+            width = len(str(bottom + 1))
+
+            template_context = "\n".join(
+                "{lineno:>{width}} {line}".format(lineno=lineno, width=width, line=line)
+                for lineno, line in source_lines
+            )
+
+            self.message += "\n\n" + template_context
 
     def __str__(self):
         return self.message

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -127,6 +127,7 @@ class Exceptions(TestCase):
 
         self.assertRegex(cm.exception.log, r"^This is LuaTeX")
         self.assertRegex(cm.exception.message, r"^! Undefined control sequence")
+        self.assertRegex(cm.exception.message, r"l\.3")
 
 
 class RenderingTemplates(TestCase):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -119,7 +119,7 @@ class Exceptions(TestCase):
         source = "\
         \\documentclass{article}\n\
         \\begin{document}\n\
-        \\unkown{command}\n\
+        \\unknown{command}\n\
         \\end{document}\n"
 
         with self.assertRaises(TexError) as cm:
@@ -128,6 +128,43 @@ class Exceptions(TestCase):
         self.assertRegex(cm.exception.log, r"^This is LuaTeX")
         self.assertRegex(cm.exception.message, r"^! Undefined control sequence")
         self.assertRegex(cm.exception.message, r"l\.3")
+
+    def test_template_debug(self):
+        source = (
+            "\\documentclass{article}\n"
+            "\\begin{document}\n"
+            "\\unknown{command}\n"
+            "\\end{document}\n"
+        )
+
+        with self.assertRaises(TexError) as cm:
+            run_tex(source)
+
+        template_debug = cm.exception.template_debug
+
+        self.assertEqual(template_debug["during"], "\\unknown{command}")
+
+    def test_template_error_context(self):
+        source = (
+            "\\documentclass{article}\n"
+            "\\begin{document}\n"
+            "\\unknown{command}\n"
+            "\\end{document}\n"
+        )
+
+        with self.assertRaises(TexError) as cm:
+            run_tex(source)
+
+        message = cm.exception.message
+
+        expected_context = (
+            "1 \\documentclass{article}\n"
+            "2 \\begin{document}\n"
+            "3 \\unknown{command}\n"
+            "4 \\end{document}"
+        )
+
+        self.assertIn(expected_context, message)
 
 
 class RenderingTemplates(TestCase):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -143,12 +143,19 @@ class Exceptions(TestCase):
         template_debug = cm.exception.template_debug
 
         self.assertEqual(template_debug["during"], "\\unknown{command}")
+        self.assertEqual(template_debug["line"], 3)
 
     def test_template_error_context(self):
         source = (
             "\\documentclass{article}\n"
+            "\n"
+            "\n"
+            "\n"
+            "\n"
             "\\begin{document}\n"
             "\\unknown{command}\n"
+            "\n"
+            "\n"
             "\\end{document}\n"
         )
 
@@ -158,10 +165,15 @@ class Exceptions(TestCase):
         message = cm.exception.message
 
         expected_context = (
-            "1 \\documentclass{article}\n"
-            "2 \\begin{document}\n"
-            "3 \\unknown{command}\n"
-            "4 \\end{document}"
+            " 2 \n"
+            " 3 \n"
+            " 4 \n"
+            " 5 \n"
+            " 6 \\begin{document}\n"
+            " 7 \\unknown{command}\n"
+            " 8 \n"
+            " 9 \n"
+            "10 \\end{document}"
         )
 
         self.assertIn(expected_context, message)


### PR DESCRIPTION
This is a proposed solution for issue #16 

If a `TexError` occurs, the context of the rendered template is provided with the error message. Further, a `template_debug` attribute is added to `TexError` as documented here [https://docs.djangoproject.com/en/3.0/topics/templates/#debug-integration-for-custom-engines](https://docs.djangoproject.com/en/3.0/topics/templates/#debug-integration-for-custom-engines) to display the context nicely in django's debug page