### PR TITLE
Replace ugettext_laxy

### DIFF
--- a/django_tex/models.py
+++ b/django_tex/models.py
@@ -1,7 +1,7 @@
 from django.db import models
 from django.core.exceptions import ValidationError
 from django.template import TemplateDoesNotExist
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.template.loader import get_template
 
 


### PR DESCRIPTION
Deprecated in Django 4 https://docs.djangoproject.com/en/dev/internals/deprecation/#deprecation-removed-in-4-0