### PR TITLE
allow passing objects to latex_escape filter

### DIFF
--- a/django_tex/filters.py
+++ b/django_tex/filters.py
@@ -26,13 +26,14 @@ REPLACEMENTS = dict(
 ESCAPE_PATTERN = re.compile("[{}]".format("".join(map(re.escape, REPLACEMENTS.keys()))))
 
 
-def do_latex_escape(value: str) -> str:
+def do_latex_escape(value: object) -> str:
     """
     Replace all LaTeX characters that could cause the latex compiler to fail
     and at the same time try to display the character as intended from the user.
 
     see also https://tex.stackexchange.com/questions/34580/escape-character-in-latex
     """
+    value = str(value)
     return ESCAPE_PATTERN.sub(lambda mo: REPLACEMENTS.get(mo.group()), value)
 
 


### PR DESCRIPTION
Without this change I get the message: 
expected string or bytes-like object
from mo.group()

when I pass in a django model instance into the `| escape_latex` filter.

e.g. I have a template where it is really handy to pass an object in the jinja context instead of lists of strings dicts:

```
\begin{itemize}
{% for service in services %}
\begin{minipage}{\textwidth}
\item {{ service | latex_escape }}\\
    {% if service.description %}
        {{ service.description | latex_escape}} \\
    {% endif %}

    {% if service.title %}
    {{ service.title | latex_escape}} \\
    {% endif %}

    {% if service.cert %}
    {{ service.cert | latex_escape}} \\
    {% endif %}

    {% if service.screenshot_path %}
    \begin{center}
        \includegraphics[width=\textwidth]{ {{service.screenshot_path }} }
    \end{center}
    {% endif %}

\end{minipage}

{% endfor %}
\end{itemize}
```

As a workaround I tried

`{{ service | string | latex_escape}}`
but that just gave me the error: ("No filter named 'string'.",)

(same for `{{ service | reverse | reverse | latex_escape}}`)