### PR TITLE
Allow for "attachment" parameter in PDFResponse content-disposition header

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ from django_tex.shortcuts import render_to_pdf
 def view(request):
     template_name = 'test.tex'
     context = {'foo': 'Bar'}
-    return render_to_pdf(request, template_name, context, filename='test.pdf')
+    return render_to_pdf(request, template_name, context, as_attachment=True, filename='test.pdf')
 ```
 
 ## Some notes on usage

--- a/django_tex/response.py
+++ b/django_tex/response.py
@@ -2,7 +2,12 @@ from django.http import HttpResponse
 
 
 class PDFResponse(HttpResponse):
-    def __init__(self, content, filename=None):
+    def __init__(self, content, as_attachment=False, filename=None):
         super(PDFResponse, self).__init__(content_type="application/pdf")
-        self["Content-Disposition"] = 'filename="{}"'.format(filename)
+        if filename:
+            disposition = "attachment" if as_attachment else "inline"
+            file_expr = 'filename="{}"'.format(filename)
+            self["Content-Disposition"] = "{}; {}".format(disposition, file_expr)
+        elif as_attachment:
+            self["Content-Disposition"] = "attachment"
         self.write(content)

--- a/django_tex/shortcuts.py
+++ b/django_tex/shortcuts.py
@@ -2,7 +2,7 @@ from django_tex.core import compile_template_to_pdf
 from django_tex.response import PDFResponse
 
 
-def render_to_pdf(request, template_name, context=None, filename=None):
+def render_to_pdf(request, template_name, context=None, as_attachment=False, filename=None):
     # Request is not needed and only included to make the signature conform to django's render function
     pdf = compile_template_to_pdf(template_name, context)
-    return PDFResponse(pdf, filename=filename)
+    return PDFResponse(pdf, as_attachment=as_attachment, filename=filename)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -359,4 +359,25 @@ class Views(TestCase):
         response = render_to_pdf(request, template_name, context, filename="test.pdf")
         self.assertIsInstance(response, HttpResponse)
         self.assertEqual(response["Content-Type"], "application/pdf")
-        self.assertEqual(response["Content-Disposition"], 'filename="test.pdf"')
+        self.assertEqual(response["Content-Disposition"], 'inline; filename="test.pdf"')
+
+    def test_render_to_pdf_content_dispositions(self):
+        request = None  # request is only needed to make the signature of render_to_pdf similar to the signature of django's render function
+        template_name = "tests/test.tex"
+        context = {
+            "test": "a simple test",
+            "number": Decimal("1000.10"),
+            "date": datetime.date(2017, 10, 25),
+            "names": ["Arjen", "Robert", "Mats"],
+        }
+        response = render_to_pdf(request, template_name, context, filename="test.pdf")
+        self.assertEqual(response["Content-Disposition"], 'inline; filename="test.pdf"')
+
+        response = render_to_pdf(request, template_name, context, as_attachment=True, filename="test.pdf")
+        self.assertEqual(response["Content-Disposition"], 'attachment; filename="test.pdf"')
+
+        response = render_to_pdf(request, template_name, context, as_attachment=True)
+        self.assertEqual(response["Content-Disposition"], 'attachment')
+
+        response = render_to_pdf(request, template_name, context)
+        self.assertFalse("Content-Disposition" in response)


### PR DESCRIPTION
Hello, thanks for this app -- very useful!

I recently ran into a situation where I wanted the the user to automatically download the file in a `PDFResponse`, rather than just viewing it in their browser. This can be done by adding the `attachment` parameter to the `Content-Disposition` header ([docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition#as_a_response_header_for_the_main_body)).

I added a new kwarg `as_attachment` to `PDFResponse` and `render_to_pdf`. It defaults to `False`, so I think this change should be backward compatible. I modeled the code after [Django's `FileResponse` class](https://github.com/django/django/blob/bb61f0186d5c490caa44f3e3672d81e14414d33c/django/http/response.py#L481).

Please let me know if you think this would be a good addition to this app, and/or if you have any feedback about the style, implementation, etc.