### PR TITLE
don't overwrite default filters

### DIFF
--- a/django_tex/environment.py
+++ b/django_tex/environment.py
@@ -11,5 +11,5 @@ def environment(**options):
         }
     )
     env = Environment(**options)
-    env.filters = FILTERS
+    env.filters.update(FILTERS)
     return env


### PR DESCRIPTION
fixes `("no filter named 'replace'",)` or ("No filter named 'string'.",) issue that was identified in https://github.com/weinbusch/django-tex/pull/33